### PR TITLE
DS-332 Use relative dates for events import

### DIFF
--- a/modules/openy_demo_nevent/config/install/migrate_plus.migration.openy_demo_node_event.yml
+++ b/modules/openy_demo_nevent/config/install/migrate_plus.migration.openy_demo_node_event.yml
@@ -19,93 +19,95 @@ source:
       id: 1
       title: 'Summer Event'
       created: '2018-04-24 8:00am'
-      start_date: '2018-04-24T10:00:00'
-      end_date: '2018-04-24T11:00:00'
+      start_date: '+31 days'
+      end_date: '+32 days'
       related: null
       image: 2
       promote: 1
       addthis: 1
-      camp: 1      
+      camp: 1
       body: >
-        <p>Ut vulputate rhoncus felis sed rhoncus. 
-        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante. 
-        Aliquam posuere velit eget ipsum vestibulum ullamcorper. 
-        Integer pellentesque elit eu sapien iaculis tristique. 
-        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; 
-        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus, 
-        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis. 
-        Phasellus nec vulputate justo, dignissim porttitor mi. 
-        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed. 
+        <p>Ut vulputate rhoncus felis sed rhoncus.
+        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante.
+        Aliquam posuere velit eget ipsum vestibulum ullamcorper.
+        Integer pellentesque elit eu sapien iaculis tristique.
+        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus,
+        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis.
+        Phasellus nec vulputate justo, dignissim porttitor mi.
+        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed.
         Etiam interdum, risus in consequat laoreet, tortor dolor dictum est, quis accumsan odio ante sed tortor.</p>
     -
       id: 2
       title: 'YMCA Event'
       created: '2017-04-23 8:01am'
-      start_date: '2018-04-23T10:00:00'
-      end_date: '2018-04-23T11:00:00'
+      start_date: '+30 days 10:00'
+      end_date: '+30 days 11:00'
       related: null
       image: 4
       promote: 0
       addthis: 1
-      camp: 2      
+      camp: 2
       body: >
-        <p>Ut vulputate rhoncus felis sed rhoncus. 
-        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante. 
-        Aliquam posuere velit eget ipsum vestibulum ullamcorper. 
-        Integer pellentesque elit eu sapien iaculis tristique. 
-        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; 
-        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus, 
-        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis. 
-        Phasellus nec vulputate justo, dignissim porttitor mi. 
-        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed. 
+        <p>Ut vulputate rhoncus felis sed rhoncus.
+        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante.
+        Aliquam posuere velit eget ipsum vestibulum ullamcorper.
+        Integer pellentesque elit eu sapien iaculis tristique.
+        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus,
+        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis.
+        Phasellus nec vulputate justo, dignissim porttitor mi.
+        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed.
         Etiam interdum, risus in consequat laoreet, tortor dolor dictum est, quis accumsan odio ante sed tortor.</p>
     -
       id: 3
       title: 'CityCon Event'
       created: '2017-04-22 8:01am'
-      start_date: '2018-04-22T16:00:00'
-      end_date: '2018-04-22T17:00:00'
+      start_date: '+7 days 16:00'
+      end_date: '+14 days 16:00'
       related: null
       image: 6
       promote: 0
       addthis: 1
-      camp: 2      
+      camp: 2
       body: >
-        <p>Ut vulputate rhoncus felis sed rhoncus. 
-        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante. 
-        Aliquam posuere velit eget ipsum vestibulum ullamcorper. 
-        Integer pellentesque elit eu sapien iaculis tristique. 
-        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; 
-        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus, 
-        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis. 
-        Phasellus nec vulputate justo, dignissim porttitor mi. 
-        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed. 
+        <p>Ut vulputate rhoncus felis sed rhoncus.
+        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante.
+        Aliquam posuere velit eget ipsum vestibulum ullamcorper.
+        Integer pellentesque elit eu sapien iaculis tristique.
+        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus,
+        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis.
+        Phasellus nec vulputate justo, dignissim porttitor mi.
+        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed.
         Etiam interdum, risus in consequat laoreet, tortor dolor dictum est, quis accumsan odio ante sed tortor.</p>
     -
       id: 4
       title: 'FanCon Event'
       created: '2017-04-21 8:01am'
-      start_date: '2018-04-21T15:00:00'
-      end_date: '2018-04-21T17:00:00'
+      start_date: '+7 days 15:00'
+      end_date: '+7 days 17:00'
       related: null
       image: 7
       promote: 0
       addthis: 1
-      camp: 1      
+      camp: 1
       body: >
-        <p>Ut vulputate rhoncus felis sed rhoncus. 
-        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante. 
-        Aliquam posuere velit eget ipsum vestibulum ullamcorper. 
-        Integer pellentesque elit eu sapien iaculis tristique. 
-        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; 
-        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus, 
-        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis. 
-        Phasellus nec vulputate justo, dignissim porttitor mi. 
-        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed. 
+        <p>Ut vulputate rhoncus felis sed rhoncus.
+        In ac laoreet ex. Aliquam leo arcu, ultrices ornare felis in, rutrum varius ante.
+        Aliquam posuere velit eget ipsum vestibulum ullamcorper.
+        Integer pellentesque elit eu sapien iaculis tristique.
+        Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        Aliquam blandit diam ut felis vulputate feugiat. Donec risus nunc, fringilla non nibh tempus,
+        ultricies tristique dolor. Integer condimentum quis ligula eu sagittis.
+        Phasellus nec vulputate justo, dignissim porttitor mi.
+        Suspendisse pellentesque nisi ipsum, in vehicula neque tempor sed.
         Etiam interdum, risus in consequat laoreet, tortor dolor dictum est, quis accumsan odio ante sed tortor.</p>
   ids:
     id:
       type: integer
+  constants:
+    date_format: 'Y-m-d\TH:i:s'
 process:
   langcode:
     plugin: default_value
@@ -148,21 +150,42 @@ process:
     -
       plugin: default_value
       default_value: full_html
-  field_event_dates/value:
+  event_start_date:
     -
       plugin: get
       source: start_date
-  field_event_dates/end_value:
+    -
+      plugin: callback
+      callable: strtotime
+  field_event_dates/value:
+    -
+      plugin: callback
+      callable: date
+      unpack_source: true
+      source:
+        - constants/date_format
+        - '@event_start_date'
+  event_end_date:
     -
       plugin: get
       source: end_date
+    -
+      plugin: callback
+      callable: strtotime
+  field_event_dates/end_value:
+    plugin: callback
+    callable: date
+    unpack_source: true
+    source:
+      - constants/date_format
+      - '@event_end_date'
   field_event_image:
     -
       plugin: migration_lookup
       migration: openy_demo_nevent_media_image
       source: image
   field_event_location:
-    - 
+    -
       plugin: migration_lookup
       migration: openy_demo_node_camp
       source: camp


### PR DESCRIPTION
Currently Events created by demo content are always in 2018. We should create these events in the future so that event functionality is testable without editing content on the sandbox.

This would have also been possible using the `date_timestamp` process plugin in openy_custom/openy_migrate, like this:

```
    -
      plugin: get
      default_value: start_date
    -
      plugin: callback
      callable: strtotime
    -
      plugin: date_timestamp
      to_format: 'Y-m-d\TH:i:s'
```

but I decided to go this route in order to not introduce that dependency.