### PR TITLE
Remove 'Swimming Lessons at the YMCA' menu link

### DIFF
--- a/modules/openy_demo_ahb/config/install/migrate_plus.migration.openy_demo_entity_ahb.yml
+++ b/modules/openy_demo_ahb/config/install/migrate_plus.migration.openy_demo_entity_ahb.yml
@@ -26,7 +26,7 @@ source:
       field_ahb_title: 'YMCA Website Services anti-spam protection - reCaptcha'
       field_ahb_description: |
         <p>In order to protect customers and your site, <a href="https://ds-docs.y.org/docs/wiki/openy-anti-spam-protection/" target="_blank">anti-spam protection is available</a> on your YMCA site.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=nHo2uL-bPyM'
+      field_ahb_video: 'https://www.youtube.com/watch?v=sx36hoDj4Wc'
       field_ahb_pages: '/admin/config/people/captcha'
       field_ahb_visibility: 'include'
     -
@@ -34,7 +34,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Managing Media'
       field_ahb_description: |
         <p>The media library stores images and files, allowing you to manage files individually and in bulk. <a href="https://ds-docs.y.org/docs/user-documentation/media/" target="_blank">Get help on managing media</a> and watch the video below to learn about setting focal points.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=_xqAYLagSwE'
+      field_ahb_video: 'https://www.youtube.com/watch?v=RgnSgr9oYm8'
       field_ahb_pages: '/admin/content/media'
       field_ahb_visibility: 'include'
     -
@@ -42,7 +42,7 @@ source:
       field_ahb_title: 'YMCA Website Services: How to Change Styles and Create a Custom Theme'
       field_ahb_description: |
         <p>Learn how to tweak your styles with the CSS Editor and create a new custom theme for even more customization.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=c1WXlyHXlrU'
+      field_ahb_video: 'https://www.youtube.com/watch?v=2tIxMC2IYCI'
       field_ahb_pages: '/admin/appearance/settings/openy_*, /admin/appearance'
       field_ahb_visibility: 'include'
     -
@@ -50,7 +50,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Demo Content'
       field_ahb_description: |
         <p>The distribution provides demo content to help you get started with your site. Learn how to use it in this video.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=GcwNW3TDnjg'
+      field_ahb_video: 'https://www.youtube.com/watch?v=QUDQ1ts3lOs'
       field_ahb_pages: '/admin/structure/migrate'
       field_ahb_visibility: 'include'
     -
@@ -58,7 +58,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Branch'
       field_ahb_description: |
         <p>Branch pages contain multiple data fields that work together to help members find the right location, hours, and amenities that fits their needs. <a href="https://ds-docs.y.org/docs/user-documentation/content-types/branch/" target="_blank">Learn more in our docs</a>.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=l5rlwyyIaMk'
+      field_ahb_video: 'https://www.youtube.com/watch?v=X0uocum2VRI'
       field_ahb_pages: '/node/add/branch'
       field_ahb_visibility: 'include'
     -
@@ -66,7 +66,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Landing Page'
       field_ahb_description: |
         <p>Landing Pages are flexible content types that use regions and paragraphs to build content. <a href="https://ds-docs.y.org/docs/user-documentation/content-types/landing-page/" target="_blank">Learn more in our docs</a>.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=JGdDCWtbNKY'
+      field_ahb_video: 'https://www.youtube.com/watch?v=xdM7Sy2W8RY'
       field_ahb_pages: '/node/add/landing_page'
       field_ahb_visibility: 'include'
     -
@@ -74,7 +74,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Content Overview'
       field_ahb_description: |
         <p>Learn more about managing content and performing bulk operations.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=UNYCB9XegDE'
+      field_ahb_video: 'https://www.youtube.com/watch?v=Aqqvm28FrqI'
       field_ahb_pages: '/admin/content'
       field_ahb_visibility: 'include'
     -
@@ -82,7 +82,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Blogs'
       field_ahb_description: |
         <p>Blog posts display timely content, articles and news pieces tagged with one or more physical locations. <a href="https://ds-docs.y.org/docs/user-documentation/content-types/blog-post/" target="_blank">Learn more in our docs</a>.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=--gW0zj4wEc&list=PL_QVggMcFfKZZlVzNcVaIWCl4WwcOr9Jk&index=1&t=10s'
+      field_ahb_video: 'https://www.youtube.com/watch?v=xL3FidaHeJk'
       field_ahb_pages: '/node/add/blog'
       field_ahb_visibility: 'include'
     -
@@ -90,7 +90,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Taxonomy'
       field_ahb_description: |
         <p>Group pieces of related content together for tagging, filtering, sorting, and grouping. <a href="https://ds-docs.y.org/docs/user-documentation/taxonomy/" target="_blank">Learn more in our docs</a>.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=y9LPj0V6tt4'
+      field_ahb_video: 'https://www.youtube.com/watch?v=UrCmOgUEjnw'
       field_ahb_pages: '/admin/structure/taxonomy'
       field_ahb_visibility: 'include'
     -
@@ -98,7 +98,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Logos'
       field_ahb_description: |
         <p>The distribution allows you to change the header and footer logos for your YMCA website.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=lrGMihUyyDE'
+      field_ahb_video: 'https://www.youtube.com/watch?v=tsyStqtEB1U'
       field_ahb_pages: '/admin/appearance/settings/openy_*'
       field_ahb_visibility: 'include'
     -
@@ -106,7 +106,7 @@ source:
       field_ahb_title: 'YMCA Website Services: User Menu'
       field_ahb_description: |
         <p>Manage utility links for user account options.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=kcOKZVM-hzg'
+      field_ahb_video: 'https://www.youtube.com/watch?v=stVYyS0ACuI'
       field_ahb_pages: '/admin/structure/menu/manage/account'
       field_ahb_visibility: 'include'
     -
@@ -114,7 +114,7 @@ source:
       field_ahb_title: 'YMCA Website Services: Header Menu'
       field_ahb_description: |
         <p>Manage primary navigation for your YMCA website.</p>
-      field_ahb_video: 'https://www.youtube.com/watch?v=3--CzMz5DPk'
+      field_ahb_video: 'https://www.youtube.com/watch?v=SpBof2cuA7k'
       field_ahb_pages: '/admin/structure/menu/manage/main'
       field_ahb_visibility: 'include'
     -
@@ -136,7 +136,7 @@ source:
           <li>Check that all conflicts were resolved according to your manual actions.</li>
           <li><strong>Deploy</strong> this update to DEV or PROD environment and run updates.</li>
         </ol>
-      field_ahb_video: 'https://www.youtube.com/watch?v=ThpCX6T4q6c'
+      field_ahb_video: 'https://www.youtube.com/watch?v=ZErC-GZKPtk'
       field_ahb_pages: '/admin/openy/development/upgrade-log/dashboard'
       field_ahb_visibility: 'include'
     -

--- a/modules/openy_demo_nlanding/openy_demo_nlanding.module
+++ b/modules/openy_demo_nlanding/openy_demo_nlanding.module
@@ -359,23 +359,6 @@ function openy_demo_nlanding_af_pages() {
   $ps_node->field_content->entity = $ps_paragraph;
   $ps_node->save();
 
-  $nid = \Drupal::service('entity_type.manager')
-    ->getStorage('node')->getQuery()->accessCheck(FALSE)
-    ->condition('title', 'Swimming Lessons at the YMCA')
-    ->condition('type', 'landing_page')
-    ->execute();
-  $nid = reset($nid);
-  $parent_menu_link = MenuLinkContent::load(39);
-  // Create menu link.
-  $menu_link = MenuLinkContent::create([
-    'title' => 'Swimming Lessons at the YMCA',
-    'link' => ['uri' => 'entity:node/' . $nid],
-    'menu_name' => 'main',
-    'parent' => $parent_menu_link ? 'menu_link_content:' . $parent_menu_link->uuid() : '',
-    'expanded' => TRUE,
-  ]);
-  $menu_link->save();
-
   // For some reason af blocks do not have block's id in their
   // configuration. This is why we manually ensure they are set up.
   $process_paragraphs = function ($prgfs) {


### PR DESCRIPTION
- Remove the 'Swimming Lessons at the YMCA' menu link creation because it conflicts with the LB demo content menu creation logic
- Merge upstream changes to the V2 branch from main branch